### PR TITLE
:wheelchair: workaround for handling 404 on /whitepaper on static files cdn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@ RUN npm run build
 # Stage 2: Serve with nginx
 FROM nginx:alpine
 # Remove default nginx content
-RUN rm -rf /usr/share/nginx/html/*
+RUN rm -rf /usr/share/nginx/html/* \
+  && sed -i 's/^\([[:space:]]*\)#[[:space:]]*\(error_page.*404.*\/404\.html;\)/\1\2/' /etc/nginx/conf.d/default.conf
 # Copy build artifacts from builder
 COPY --from=builder /app/dist /usr/share/nginx/html
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,9 +1,29 @@
 import { defineConfig } from 'vite'
+import path from 'path'
+import { copyFileSync } from 'fs'
 import react from '@vitejs/plugin-react'
+
+const copy404Plugin = () => {
+  return {
+    name: 'copy-404',
+    closeBundle() {
+      const distPath = path.resolve(process.cwd(), 'dist')
+      const indexPath = path.join(distPath, 'index.html')
+      const notFoundPath = path.join(distPath, '404.html')
+
+      try {
+        copyFileSync(indexPath, notFoundPath)
+        console.log('✅ Successfully copied index.html to 404.html')
+      } catch (error) {
+        console.error('❌ Failed to copy 404.html:', error)
+      }
+    }
+  }
+}
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), copy404Plugin()],
   base: "/",
   // server: {
   //   allowedHosts: true

--- a/vite.config.js
+++ b/vite.config.js
@@ -27,5 +27,5 @@ export default defineConfig({
   base: "/",
   // server: {
   //   allowedHosts: true
-  // }
+  // },
 })


### PR DESCRIPTION
change

* ♿ workaround for handling `404` on `/whitepaper` on static files cdn

Signed-off-by: Lǎo Yè <zib0dts9@duck.com>
